### PR TITLE
Added ember-template-lint support

### DIFF
--- a/server/src/project-roots.ts
+++ b/server/src/project-roots.ts
@@ -28,9 +28,9 @@ export default class ProjectRoots {
   }
 
   rootForPath(path: string) {
-    return this.projectRoots
+    return (this.projectRoots || [])
       .filter(root => path.indexOf(root) === 0)
-      .reduce((a, b) => a.length > b.length ? a : b);
+      .reduce((a, b) => a.length > b.length ? a : b, '');
   }
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,7 +49,6 @@ export default class Server {
     // Bind event handlers
     this.connection.onInitialize(this.onInitialize.bind(this));
     this.documents.onDidChangeContent(this.onDidChangeContent.bind(this));
-    this.connection.onDidOpenTextDocument(this.onDidOpenTextDocument.bind(this));
     this.connection.onDidChangeWatchedFiles(this.onDidChangeWatchedFiles.bind(this));
     this.connection.onDocumentSymbol(this.onDocumentSymbol.bind(this));
     this.connection.onDefinition(this.definitionProvider.handler);
@@ -88,10 +87,6 @@ export default class Server {
 
   private onDidChangeContent(change: any) {
     this.templateLinter.lint(change.document);
-  }
-
-  private onDidOpenTextDocument({ textDocument }: any) {
-    this.templateLinter.lint(textDocument);
   }
 
   private onDidChangeWatchedFiles() {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -16,6 +16,7 @@ import {
 
 import ProjectRoots from './project-roots';
 import DefinitionProvider from './definition-provider';
+import TemplateLinter from './template-linter';
 import DocumentSymbolProvider from './symbols/document-symbol-provider';
 import JSDocumentSymbolProvider from './symbols/js-document-symbol-provider';
 import HBSDocumentSymbolProvider from './symbols/hbs-document-symbol-provider';
@@ -38,6 +39,8 @@ export default class Server {
 
   definitionProvider: DefinitionProvider = new DefinitionProvider(this);
 
+  templateLinter: TemplateLinter = new TemplateLinter(this);
+
   constructor() {
     // Make the text document manager listen on the connection
     // for open, change and close text document events
@@ -46,6 +49,7 @@ export default class Server {
     // Bind event handlers
     this.connection.onInitialize(this.onInitialize.bind(this));
     this.documents.onDidChangeContent(this.onDidChangeContent.bind(this));
+    this.connection.onDidOpenTextDocument(this.onDidOpenTextDocument.bind(this));
     this.connection.onDidChangeWatchedFiles(this.onDidChangeWatchedFiles.bind(this));
     this.connection.onDocumentSymbol(this.onDocumentSymbol.bind(this));
     this.connection.onDefinition(this.definitionProvider.handler);
@@ -82,8 +86,12 @@ export default class Server {
     };
   }
 
-  private onDidChangeContent() {
-    // here be dragons
+  private onDidChangeContent(change: any) {
+    this.templateLinter.lint(change.document);
+  }
+
+  private onDidOpenTextDocument({ textDocument }: any) {
+    this.templateLinter.lint(textDocument);
   }
 
   private onDidChangeWatchedFiles() {

--- a/server/src/template-linter.ts
+++ b/server/src/template-linter.ts
@@ -49,6 +49,11 @@ export default class TemplateLinter {
   private getLinterConfig(uri: string): { configPath: string } | undefined {
     const filePath = uriToFilePath(uri);
     const rootPath = this.server.projectRoots.rootForPath(filePath);
+
+    if (!rootPath) {
+      return;
+    }
+
     const configPath = path.join(rootPath, '.template-lintrc.js');
 
     if (!fs.existsSync(configPath)) {
@@ -63,6 +68,10 @@ export default class TemplateLinter {
   private async getLinter(uri: string) {
     const filePath = uriToFilePath(uri);
     const rootPath = this.server.projectRoots.rootForPath(filePath);
+
+    if (!rootPath) {
+      return;
+    }
 
     if (this._linter[rootPath]) {
       return this._linter;

--- a/server/src/template-linter.ts
+++ b/server/src/template-linter.ts
@@ -1,0 +1,80 @@
+import { Diagnostic, DiagnosticSeverity, Files, TextDocument } from 'vscode-languageserver';
+import { uriToFilePath } from 'vscode-languageserver/lib/files';
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+import Server from './server';
+
+export default class TemplateLinter {
+
+  private _linter: any = {};
+
+  constructor(private server: Server) {}
+
+  async lint(textDocument: TextDocument) {
+    if (textDocument.languageId !== 'handlebars') {
+      return;
+    }
+
+    const config = this.getLinterConfig(textDocument.uri);
+
+    if (!config) {
+      return;
+    }
+
+    const TemplateLinter = await this.getLinter(textDocument.uri);
+    const linter = new TemplateLinter(config);
+
+    const errors = linter.verify({
+      source: textDocument.getText(),
+      moduleId: textDocument.uri
+    });
+
+    const diagnostics: Diagnostic[] = errors.map((error: any) => {
+      return {
+        severity: DiagnosticSeverity.Error,
+        range: {
+          start: { line: error.line - 1, character: error.column },
+          end: { line: error.line - 1, character: error.column + 1 }
+        },
+        message: error.message,
+        source: 'ember-template-lint'
+      };
+    });
+
+    this.server.connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+  }
+
+  private getLinterConfig(uri: string): { configPath: string } | undefined {
+    const filePath = uriToFilePath(uri);
+    const rootPath = this.server.projectRoots.rootForPath(filePath);
+    const configPath = path.join(rootPath, '.template-lintrc.js');
+
+    if (!fs.existsSync(configPath)) {
+      return;
+    }
+
+    return {
+      configPath
+    };
+  }
+
+  private async getLinter(uri: string) {
+    const filePath = uriToFilePath(uri);
+    const rootPath = this.server.projectRoots.rootForPath(filePath);
+
+    if (this._linter[rootPath]) {
+      return this._linter;
+    }
+
+    return Files.resolveModule(rootPath, 'ember-template-lint')
+      .then(resolvedLinter => {
+        this._linter[rootPath] = resolvedLinter;
+
+        return resolvedLinter;
+      }, () => {
+        console.log('Module ember-template-lint not found.');
+      });
+  }
+}

--- a/server/src/template-linter.ts
+++ b/server/src/template-linter.ts
@@ -77,13 +77,12 @@ export default class TemplateLinter {
       return this._linterCache.get(rootPath);
     }
 
-    return Files.resolveModule(rootPath, 'ember-template-lint')
-      .then(resolvedLinter => {
-        this._linterCache.set(rootPath, resolvedLinter);
-
-        return resolvedLinter;
-      }, () => {
-        console.log('Module ember-template-lint not found.');
-      });
+    try {
+      const linter = await Files.resolveModule(rootPath, 'ember-template-lint');
+      this._linterCache.set(rootPath, linter);
+      return linter;
+    } catch (error) {
+      console.log('Module ember-template-lint not found.');
+    }
   }
 }

--- a/server/src/template-linter.ts
+++ b/server/src/template-linter.ts
@@ -8,7 +8,7 @@ import Server from './server';
 
 export default class TemplateLinter {
 
-  private _linter: any = {};
+  private _linterCache = new Map();
 
   constructor(private server: Server) {}
 
@@ -73,13 +73,13 @@ export default class TemplateLinter {
       return;
     }
 
-    if (this._linter[rootPath]) {
-      return this._linter;
+    if (this._linterCache.has(rootPath)) {
+      return this._linterCache.get(rootPath);
     }
 
     return Files.resolveModule(rootPath, 'ember-template-lint')
       .then(resolvedLinter => {
-        this._linter[rootPath] = resolvedLinter;
+        this._linterCache.set(rootPath, resolvedLinter);
 
         return resolvedLinter;
       }, () => {

--- a/server/src/template-linter.ts
+++ b/server/src/template-linter.ts
@@ -48,6 +48,10 @@ export default class TemplateLinter {
 
   private getLinterConfig(uri: string): { configPath: string } | undefined {
     const filePath = uriToFilePath(uri);
+    if (!filePath) {
+      return;
+    }
+
     const rootPath = this.server.projectRoots.rootForPath(filePath);
 
     if (!rootPath) {
@@ -67,6 +71,10 @@ export default class TemplateLinter {
 
   private async getLinter(uri: string) {
     const filePath = uriToFilePath(uri);
+    if (!filePath) {
+      return;
+    }
+
     const rootPath = this.server.projectRoots.rootForPath(filePath);
 
     if (!rootPath) {


### PR DESCRIPTION
This works almost perfect.  
After opening a VSCode instance the linter for the files that are opened up directly kicks in before the `projectRoots` are set. So `rootForPath` returns no valid path and linting won't work. Linting errors will appear as soon as you type something in the template.

Any suggestions on how to properly solve this problem? I thought about changing `rootForPath` to return a promise and only resolve once the `projectRoot` are initialized but I think we can't use asynchronous stuff in the definition provider (not sure about that one though).