### PR TITLE
Enable TypeScript compiler options

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "vscode-languageserver": "^2.6.2"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.34",
     "@types/esprima": "^2.1.33",
     "@types/estree": "*",
     "@types/mocha": "^2.2.38",

--- a/server/src/ast.ts
+++ b/server/src/ast.ts
@@ -1,6 +1,7 @@
+import { SourceLocation } from 'estree';
 import { Range, Position } from 'vscode-languageserver';
 
-export function locToRange(loc): Range {
+export function locToRange(loc: SourceLocation): Range {
   let start = Position.create(loc.start.line - 1, loc.start.column);
   let end = Position.create(loc.end.line - 1, loc.end.column);
   return Range.create(start, end);

--- a/server/src/definition-provider.ts
+++ b/server/src/definition-provider.ts
@@ -12,7 +12,7 @@ import Server from './server';
 export default class DefinitionProvider {
   constructor(private server: Server) {}
 
-  handle(params: TextDocumentPositionParams): Definition {
+  handle(params: TextDocumentPositionParams): Definition | null {
     let uri = params.textDocument.uri;
     let filePath = uriToFilePath(uri);
     let root = this.server.projectRoots.rootForPath(filePath);
@@ -69,7 +69,7 @@ export default class DefinitionProvider {
 function findFocusPath(node: any, position: Position, seen = new Set()): any {
   seen.add(node);
 
-  let path = [];
+  let path: any[] = [];
   let range: SourceLocation = node.loc;
   if (range) {
     if (containsPosition(range, position)) {

--- a/server/src/definition-provider.ts
+++ b/server/src/definition-provider.ts
@@ -5,9 +5,10 @@ import { RequestHandler, TextDocumentPositionParams, Definition, Location, Range
 import { uriToFilePath } from 'vscode-languageserver/lib/files';
 import { Position, SourceLocation } from 'estree';
 
-import { preprocess, traverse } from '@glimmer/syntax';
 import { toPosition, containsPosition } from './estree-utils';
 import Server from './server';
+
+const { preprocess } = require('@glimmer/syntax');
 
 export default class DefinitionProvider {
   constructor(private server: Server) {}

--- a/server/src/project-roots.ts
+++ b/server/src/project-roots.ts
@@ -40,11 +40,11 @@ export default class ProjectRoots {
 
 export function findProjectRoots(workspaceRoot: string): Promise<string[]> {
   return new Promise(resolve => {
-    let filter = it => ignoredFolders.indexOf(basename(it)) === -1;
+    let filter = (it: string) => ignoredFolders.indexOf(basename(it)) === -1;
 
     let projectRoots: string[] = [];
     klaw(workspaceRoot, { filter })
-      .on('data', item => {
+      .on('data', (item: any) => {
         if (basename(item.path) === 'ember-cli-build.js') {
           projectRoots.push(dirname(item.path));
         }

--- a/server/src/project-roots.ts
+++ b/server/src/project-roots.ts
@@ -42,7 +42,7 @@ export function findProjectRoots(workspaceRoot: string): Promise<string[]> {
   return new Promise(resolve => {
     let filter = it => ignoredFolders.indexOf(basename(it)) === -1;
 
-    let projectRoots = [];
+    let projectRoots: string[] = [];
     klaw(workspaceRoot, { filter })
       .on('data', item => {
         if (basename(item.path) === 'ember-cli-build.js') {

--- a/server/src/project-roots.ts
+++ b/server/src/project-roots.ts
@@ -4,8 +4,6 @@ import { basename, dirname } from 'path';
 
 import { InitializeParams } from 'vscode-languageserver';
 
-import Server from './server';
-
 const klaw = require('klaw');
 
 const ignoredFolders: string[] = [
@@ -19,7 +17,7 @@ export default class ProjectRoots {
   workspaceRoot: string;
   projectRoots: string[];
 
-  constructor(private server: Server) {}
+  constructor() {}
 
   async initialize(params: InitializeParams) {
     this.workspaceRoot = params.rootPath;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,7 +11,7 @@ import {
   IPCMessageReader, IPCMessageWriter,
   createConnection, IConnection,
   TextDocuments, InitializeResult, InitializeParams, DocumentSymbolParams,
-  SymbolInformation, DidChangeWatchedFilesParams
+  SymbolInformation
 } from 'vscode-languageserver';
 
 import { uriToFilePath } from 'vscode-languageserver/lib/files';
@@ -75,11 +75,11 @@ export default class Server {
     };
   }
 
-  private onDidChangeContent(change: any) {
+  private onDidChangeContent() {
     // here be dragons
   }
 
-  private onDidChangeWatchedFiles(change: DidChangeWatchedFilesParams) {
+  private onDidChangeWatchedFiles() {
     // here be dragons
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,7 +11,7 @@ import {
   IPCMessageReader, IPCMessageWriter,
   createConnection, IConnection,
   TextDocuments, InitializeResult, InitializeParams, DocumentSymbolParams,
-  SymbolInformation,
+  SymbolInformation, DidChangeWatchedFilesParams
 } from 'vscode-languageserver';
 
 import { uriToFilePath } from 'vscode-languageserver/lib/files';
@@ -75,11 +75,11 @@ export default class Server {
     };
   }
 
-  private onDidChangeContent(change) {
+  private onDidChangeContent(change: any) {
     // here be dragons
   }
 
-  private onDidChangeWatchedFiles(change) {
+  private onDidChangeWatchedFiles(change: DidChangeWatchedFilesParams) {
     // here be dragons
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { basename, dirname, extname } from 'path';
+import { extname } from 'path';
 import { readFileSync } from 'fs';
 
 import {
@@ -31,7 +31,7 @@ export default class Server {
   // supports full document sync only
   documents: TextDocuments = new TextDocuments();
 
-  projectRoots: ProjectRoots = new ProjectRoots(this);
+  projectRoots: ProjectRoots = new ProjectRoots();
 
   documentSymbolProviders: DocumentSymbolProvider[] = [
     new JSDocumentSymbolProvider(),

--- a/server/src/symbols/hbs-document-symbol-provider.ts
+++ b/server/src/symbols/hbs-document-symbol-provider.ts
@@ -1,5 +1,5 @@
 import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
-import { preprocess, traverse } from '@glimmer/syntax';
+const { preprocess, traverse } = require('@glimmer/syntax');
 
 import DocumentSymbolProvider from './document-symbol-provider';
 import { locToRange } from '../ast';
@@ -13,10 +13,10 @@ export default class HBSDocumentSymbolProvider implements DocumentSymbolProvider
     let symbols: SymbolInformation[] = [];
 
     traverse(ast, {
-      BlockStatement(node) {
+      BlockStatement(node: any) {
         if (node.program.blockParams.length === 0) return;
 
-        node.program.blockParams.forEach(blockParam => {
+        node.program.blockParams.forEach((blockParam: string) => {
           let symbol = SymbolInformation.create(blockParam, SymbolKind.Variable, locToRange(node.loc));
           symbols.push(symbol);
         });

--- a/server/src/symbols/js-document-symbol-provider.ts
+++ b/server/src/symbols/js-document-symbol-provider.ts
@@ -1,8 +1,9 @@
 import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
 import { parse } from 'esprima';
-import * as types from 'ast-types';
 import DocumentSymbolProvider from './document-symbol-provider';
 import { locToRange } from '../ast';
+
+const types = require('ast-types');
 
 export default class JSDocumentSymbolProvider implements DocumentSymbolProvider {
   extensions: string[] = ['.js'];
@@ -16,7 +17,7 @@ export default class JSDocumentSymbolProvider implements DocumentSymbolProvider 
     let symbols: SymbolInformation[] = [];
 
     types.visit(ast, {
-      visitProperty(path) {
+      visitProperty(path: any) {
         let node = path.node;
 
         let symbol = SymbolInformation.create(node.key.name, SymbolKind.Property, locToRange(node.key.loc));

--- a/server/test/estree-utils-test.ts
+++ b/server/test/estree-utils-test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+const { expect } = require('chai');
 
 import { Position as LSPosition } from 'vscode-languageserver';
 

--- a/server/test/position-utils-test.ts
+++ b/server/test/position-utils-test.ts
@@ -2,7 +2,7 @@ import { Position } from 'vscode-languageserver';
 
 import { compare } from '../src/position-utils';
 
-const expect = require('chai').expect;
+import { expect } from 'chai';
 
 describe('position-utils', function() {
   describe('compare()', function() {

--- a/server/test/range-utils-test.ts
+++ b/server/test/range-utils-test.ts
@@ -2,7 +2,7 @@ import { Range, Position } from 'vscode-languageserver';
 
 import { contains } from '../src/range-utils';
 
-const expect = require('chai').expect;
+import { expect } from 'chai';
 
 describe('range-utils', function() {
   describe('contains()', function() {

--- a/server/test/server.ts
+++ b/server/test/server.ts
@@ -1,6 +1,6 @@
 import { findProjectRoots } from '../src/project-roots';
 
-const expect = require('chai').expect;
+import { expect } from 'chai';
 
 describe('findProjectRoots()', function() {
   it('finds nested projects', async function() {

--- a/server/test/tslint.ts
+++ b/server/test/tslint.ts
@@ -1,3 +1,3 @@
-import * as lint from 'mocha-tslint';
+const lint = require('mocha-tslint');
 
 lint('./tslint.json', ['src', 'test']);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,7 +10,8 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noFallthroughCasesInSwitch": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "pretty": true
   },
   "exclude": [
     "node_modules"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "lib" : [ "es2016" ],
-    "outDir": "../client/server"
+    "outDir": "../client/server",
+    "strictNullChecks": true
   },
   "exclude": [
     "node_modules"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -7,7 +7,8 @@
     "lib" : [ "es2016" ],
     "outDir": "../client/server",
     "strictNullChecks": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "noUnusedLocals": true
   },
   "exclude": [
     "node_modules"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,6 +9,7 @@
     "strictNullChecks": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "newLine": "LF",
     "pretty": true

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,6 +9,7 @@
     "strictNullChecks": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
     "newLine": "LF"
   },
   "exclude": [

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "../client/server",
     "strictNullChecks": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "newLine": "LF"
   },
   "exclude": [
     "node_modules"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,7 +6,8 @@
     "sourceMap": true,
     "lib" : [ "es2016" ],
     "outDir": "../client/server",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "noImplicitAny": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This PR enables a few more TS [compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to do more strict type checking in our own code.

Inspired by https://github.com/tildeio/glimmer/blob/master/tsconfig.json and https://twitter.com/lukemelia/status/825056563299639296.

/cc @t-sauer @locks 