### PR TITLE
Change transport type to stdio

### DIFF
--- a/src/file-index.ts
+++ b/src/file-index.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 
 import {FileInfo, ModuleFileInfo} from './file-info';
 import Deferred from './utils/deferred';
+import Server from './server';
 
 const klaw = require('klaw');
 
@@ -18,7 +19,7 @@ export default class FileIndex {
   readonly root: string;
   readonly files: FileInfo[] = [];
 
-  constructor(root: string) {
+  constructor(root: string, private readonly server: Server | null = null) {
     this.root = root;
   }
 
@@ -38,7 +39,7 @@ export default class FileIndex {
     let relativePath = path.relative(this.root, absolutePath);
     let fileInfo = FileInfo.from(relativePath);
     if (fileInfo) {
-      console.log(`add ${relativePath} -> ${fileInfo.containerName}`);
+      this.server && this.server.connection.console.log(`add ${relativePath} -> ${fileInfo.containerName}`);
       this.files.push(fileInfo);
     }
     return fileInfo;
@@ -49,7 +50,7 @@ export default class FileIndex {
     let index = this.files.findIndex(fileInfo => fileInfo.relativePath === relativePath);
     if (index !== -1) {
       let fileInfo = this.files.splice(index, 1)[0];
-      console.log(`remove ${relativePath} -> ${fileInfo.containerName}`);
+      this.server && this.server.connection.console.log(`remove ${relativePath} -> ${fileInfo.containerName}`);
       return fileInfo;
     }
   }

--- a/src/file-info.ts
+++ b/src/file-info.ts
@@ -128,6 +128,9 @@ export class AcceptanceTestFileInfo extends TestFileInfo {
 
 function removeExtension(nameParts: string[]) {
   let baseName = nameParts.pop() as string;
+  if (!baseName) {
+    return [];
+  }
   let extension = path.extname(baseName);
   nameParts.push(baseName.substr(0, baseName.length - extension.length));
   return nameParts;

--- a/src/project-roots.ts
+++ b/src/project-roots.ts
@@ -4,12 +4,13 @@ import { basename, dirname } from 'path';
 import { EventEmitter } from 'events';
 
 import FileIndex from './file-index';
+import Server from './server';
 
 export class Project {
   readonly fileIndex: FileIndex;
 
-  constructor(public readonly root: string) {
-    this.fileIndex = new FileIndex(root);
+  constructor(public readonly root: string, server: Server) {
+    this.fileIndex = new FileIndex(root, server);
   }
 }
 
@@ -17,6 +18,8 @@ export default class ProjectRoots {
   workspaceRoot: string;
 
   projects = new Map<string, Project>();
+
+  constructor(private readonly server: Server) {}
 
   async initialize(workspaceRoot: string, watcher: EventEmitter) {
     this.workspaceRoot = workspaceRoot;
@@ -55,12 +58,12 @@ export default class ProjectRoots {
   }
 
   onProjectAdd(path: string) {
-    console.log(`Ember CLI project added at ${path}`);
-    this.projects.set(path, new Project(path));
+    this.server.connection.console.log(`Ember CLI project added at ${path}`);
+    this.projects.set(path, new Project(path, this.server));
   }
 
   onProjectDelete(path: string) {
-    console.log(`Ember CLI project deleted at ${path}`);
+    this.server.connection.console.log(`Ember CLI project deleted at ${path}`);
     this.projects.delete(path);
   }
 

--- a/src/template-linter.ts
+++ b/src/template-linter.ts
@@ -86,7 +86,7 @@ export default class TemplateLinter {
       this._linterCache.set(project, linter);
       return linter;
     } catch (error) {
-      console.log('Module ember-template-lint not found.');
+      this.server.connection.console.log('Module ember-template-lint not found.');
     }
   }
 }


### PR DESCRIPTION
The LSP client for Atom (https://github.com/atom/atom-languageclient) seems to be only supporting the stdio transport kind. Since VSCode can do both I guess we should switch over.

When we use stdio we can't use normal `console.log` anymore though, and we have to use `connection.console.log` which seems to be pretty annoying. If anyone has any better suggestions I'm open for everything.