### PR TITLE
Require parentheses around single param arrow functions

### DIFF
--- a/src/definition-provider.ts
+++ b/src/definition-provider.ts
@@ -41,7 +41,7 @@ export default class DefinitionProvider {
         const componentOrHelperName = focusPath.node.original;
 
         return project.fileIndex.files
-          .filter(fileInfo => {
+          .filter((fileInfo) => {
             if (fileInfo instanceof ModuleFileInfo) {
               return (fileInfo.type === 'component' || fileInfo.type === 'helper') &&
                 fileInfo.slashName === componentOrHelperName;
@@ -50,7 +50,7 @@ export default class DefinitionProvider {
               return fileInfo.forComponent && fileInfo.slashName === componentOrHelperName;
             }
           })
-          .map(fileInfo => toLocation(fileInfo, project.root));
+          .map((fileInfo) => toLocation(fileInfo, project.root));
       }
     } else if (extension === '.js') {
       let content = this.server.documents.get(uri).getText();
@@ -67,19 +67,19 @@ export default class DefinitionProvider {
         let modelName = astPath.node.value;
 
         return project.fileIndex.files
-          .filter(fileInfo => fileInfo instanceof ModuleFileInfo &&
+          .filter((fileInfo) => fileInfo instanceof ModuleFileInfo &&
             fileInfo.type === 'model' &&
             fileInfo.name === modelName)
-          .map(fileInfo => toLocation(fileInfo, project.root));
+          .map((fileInfo) => toLocation(fileInfo, project.root));
 
       } else if (isTransformReference(astPath)) {
         let transformName = astPath.node.value;
 
         return project.fileIndex.files
-          .filter(fileInfo => fileInfo instanceof ModuleFileInfo &&
+          .filter((fileInfo) => fileInfo instanceof ModuleFileInfo &&
             fileInfo.type === 'transform' &&
             fileInfo.name === transformName)
-          .map(fileInfo => toLocation(fileInfo, project.root));
+          .map((fileInfo) => toLocation(fileInfo, project.root));
       }
     }
 

--- a/src/file-index.ts
+++ b/src/file-index.ts
@@ -46,7 +46,7 @@ export default class FileIndex {
 
   public remove(absolutePath: string): FileInfo | undefined {
     let relativePath = path.relative(this.root, absolutePath);
-    let index = this.files.findIndex(fileInfo => fileInfo.relativePath === relativePath);
+    let index = this.files.findIndex((fileInfo) => fileInfo.relativePath === relativePath);
     if (index !== -1) {
       let fileInfo = this.files.splice(index, 1)[0];
       console.log(`remove ${relativePath} -> ${fileInfo.containerName}`);
@@ -55,6 +55,6 @@ export default class FileIndex {
   }
 
   public byModuleType(type: string) {
-    return this.files.filter(it => it instanceof ModuleFileInfo && it.type === type);
+    return this.files.filter((it) => it instanceof ModuleFileInfo && it.type === type);
   }
 }

--- a/src/project-roots.ts
+++ b/src/project-roots.ts
@@ -21,7 +21,7 @@ export default class ProjectRoots {
   async initialize(workspaceRoot: string, watcher: EventEmitter) {
     this.workspaceRoot = workspaceRoot;
 
-    let promise = new Promise(resolve => {
+    let promise = new Promise((resolve) => {
       watcher.once('ready', resolve);
     });
 
@@ -66,7 +66,7 @@ export default class ProjectRoots {
 
   projectForPath(path: string): Project | undefined {
     let root = (Array.from(this.projects.keys()) || [])
-      .filter(root => path.indexOf(root) === 0)
+      .filter((root) => path.indexOf(root) === 0)
       .reduce((a, b) => a.length > b.length ? a : b, '');
 
     return this.projects.get(root);

--- a/src/server.ts
+++ b/src/server.ts
@@ -130,14 +130,14 @@ export default class Server {
     let extension = extname(filePath);
 
     let providers = this.documentSymbolProviders
-      .filter(provider => provider.extensions.indexOf(extension) !== -1);
+      .filter((provider) => provider.extensions.indexOf(extension) !== -1);
 
     if (providers.length === 0) return [];
 
     let content = readFileSync(filePath, 'utf-8');
 
     return providers
-      .map(providers => providers.process(content))
+      .map((providers) => providers.process(content))
       .reduce((a, b) => a.concat(b), []);
   }
 }

--- a/src/utils/chokidar.ts
+++ b/src/utils/chokidar.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 export function readyEvent(watcher: EventEmitter): Promise<undefined> {
-  return new Promise<undefined>(resolve => {
+  return new Promise<undefined>((resolve) => {
     watcher.once('ready', resolve);
   });
 }

--- a/test/chokidar-test.ts
+++ b/test/chokidar-test.ts
@@ -144,7 +144,7 @@ async function listEventsUntilReady(watcher: EventEmitter): Promise<{ event: str
 }
 
 function event(watcher: EventEmitter, event: string, path: string): Promise<undefined> {
-  return new Promise<undefined>(resolve => {
+  return new Promise<undefined>((resolve) => {
     let listener = (_event: string, _path: string) => {
       if (_event === event && _path === path) {
         resolve();

--- a/test/file-index-test.ts
+++ b/test/file-index-test.ts
@@ -41,7 +41,7 @@ describe('FileIndex', function() {
     expect(index.byModuleType('service'), 'Service').to.have.lengthOf(1);
     expect(index.byModuleType('transform'), 'Transform').to.have.lengthOf(1);
 
-    expect(index.files.filter(it => it instanceof TemplateFileInfo)).to.have.lengthOf(2);
+    expect(index.files.filter((it) => it instanceof TemplateFileInfo)).to.have.lengthOf(2);
   });
 
   it('indexes modules in subdirectories', async function() {
@@ -60,7 +60,7 @@ describe('FileIndex', function() {
     await index.invalidate();
 
     expect(index.files).to.have.lengthOf(2);
-    expect(index.files.filter(it => it instanceof TemplateFileInfo && it.forComponent)).to.have.lengthOf(1);
-    expect(index.files.filter(it => it instanceof TemplateFileInfo && !it.forComponent)).to.have.lengthOf(1);
+    expect(index.files.filter((it) => it instanceof TemplateFileInfo && it.forComponent)).to.have.lengthOf(1);
+    expect(index.files.filter((it) => it instanceof TemplateFileInfo && !it.forComponent)).to.have.lengthOf(1);
   });
 });

--- a/test/file-info-test.ts
+++ b/test/file-info-test.ts
@@ -36,7 +36,7 @@ describe('FileInfo', function() {
     test('app/resolver.js', MainFileInfo, { name: 'resolver' });
     test('app/router.js', MainFileInfo, { name: 'router' });
 
-    moduleTypes.forEach(type => {
+    moduleTypes.forEach((type) => {
       test(`app/${type}s/foo.js`, ModuleFileInfo, {
         type,
         name: 'foo',
@@ -44,7 +44,7 @@ describe('FileInfo', function() {
       });
     });
 
-    moduleTypes.forEach(type => {
+    moduleTypes.forEach((type) => {
       test(`tests/integration/${type}s/foo.js`, ModuleTestFileInfo, {
         type: 'integration',
         subjectType: type,
@@ -53,7 +53,7 @@ describe('FileInfo', function() {
       });
     });
 
-    moduleTypes.forEach(type => {
+    moduleTypes.forEach((type) => {
       test(`tests/unit/${type}s/foo.js`, ModuleTestFileInfo, {
         type: 'unit',
         subjectType: type,

--- a/tslint.json
+++ b/tslint.json
@@ -2,8 +2,7 @@
   "defaultSeverity": "error",
   "rules": {
     "arrow-parens": [
-      true,
-      "ban-single-arg-parens"
+      true
     ],
     "class-name": true,
     "comment-format": [


### PR DESCRIPTION
This rule is driving me crazy.