### PR TITLE
Fix file uri in definition responses

### DIFF
--- a/src/definition-provider.ts
+++ b/src/definition-provider.ts
@@ -124,7 +124,7 @@ function isTransformReference(astPath: ASTPath): boolean {
 }
 
 function toLocation(fileInfo: FileInfo, root: string) {
-  let uri = `file:${path.join(root, fileInfo.relativePath)}`;
+  let uri = `file://${path.join(root, fileInfo.relativePath)}`;
   let range = Range.create(0, 0, 0, 0);
   return Location.create(uri, range);
 }


### PR DESCRIPTION
The file URIs were missing two slashes. Which breaks the [`uriToPath()`](https://github.com/atom/atom-languageclient/blob/master/lib/convert.js#L15) implementation in [`atom-languageclient`](https://github.com/atom/atom-languageclient).