### PR TITLE
Use rootPath if rootUri is not present in InitializeParams

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -67,12 +67,9 @@ export default class Server {
 
   // After the server has started the client sends an initilize request. The server receives
   // in the passed params the rootPath of the workspace plus the client capabilites.
-  private async onInitialize({ rootUri }: InitializeParams): Promise<InitializeResult> {
-    if (!rootUri) {
-      return { capabilities: {} };
-    }
+  private async onInitialize({ rootUri, rootPath }: InitializeParams): Promise<InitializeResult> {
 
-    let rootPath = Files.uriToFilePath(rootUri);
+    rootPath = rootUri ? Files.uriToFilePath(rootUri) : rootPath;
     if (!rootPath) {
       return { capabilities: {} };
     }


### PR DESCRIPTION
Although `rootPath` is deprecated in v3, it should also been handled if  `rootUri` is not present.

> - add a rootUri property to the initializeParams in favour of the rootPath property.

=> [Microsoft/language-server-protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#language-server-protocol)

I need this, because `atom-languageclient` only provides `rootPath` to the language server and the maintainer prefers not to add any of the version 3 of the protocol until it is more stable.

See: atom/atom-languageclient#38.