### PR TITLE
Use file extension instead of languageId to detect template files

### DIFF
--- a/src/definition-provider.ts
+++ b/src/definition-provider.ts
@@ -9,6 +9,7 @@ import { toPosition } from './estree-utils';
 import Server from './server';
 import ASTPath from './glimmer-utils';
 import { FileInfo, ModuleFileInfo, TemplateFileInfo } from './file-info';
+import { getExtension } from './utils/file-extension';
 
 const { preprocess } = require('@glimmer/syntax');
 
@@ -27,7 +28,7 @@ export default class DefinitionProvider {
       return null;
     }
 
-    let extension = path.extname(filePath);
+    let extension = getExtension(params.textDocument);
 
     if (extension === '.hbs') {
       let content = this.server.documents.get(uri).getText();

--- a/src/template-linter.ts
+++ b/src/template-linter.ts
@@ -1,5 +1,6 @@
 import { Diagnostic, DiagnosticSeverity, Files, TextDocument } from 'vscode-languageserver';
 import { uriToFilePath } from 'vscode-languageserver/lib/files';
+import { hasExtension } from './utils/file-extension';
 
 import * as path from 'path';
 import * as fs from 'fs';
@@ -14,7 +15,7 @@ export default class TemplateLinter {
   constructor(private server: Server) {}
 
   async lint(textDocument: TextDocument) {
-    if (textDocument.languageId !== 'handlebars') {
+    if (!hasExtension(textDocument, '.hbs')) {
       return;
     }
 

--- a/src/utils/file-extension.ts
+++ b/src/utils/file-extension.ts
@@ -1,0 +1,19 @@
+import { extname } from 'path';
+import { TextDocumentIdentifier } from 'vscode-languageserver';
+import { uriToFilePath } from 'vscode-languageserver/lib/files';
+
+export function getExtension(textDocument: TextDocumentIdentifier): string | null {
+  const filePath = uriToFilePath(textDocument.uri);
+  const ext = filePath ? extname(filePath) : '';
+
+  if (ext === '.handlebars') {
+    return '.hbs';
+  }
+  return ext;
+}
+
+export function hasExtension(textDocument: TextDocumentIdentifier, ...extensions: string[]): boolean {
+  const ext = getExtension(textDocument);
+
+  return ext !== null && extensions.includes(ext);
+}

--- a/test/file-extension-utils-test.ts
+++ b/test/file-extension-utils-test.ts
@@ -1,0 +1,23 @@
+import { getExtension, hasExtension } from '../src/utils/file-extension';
+import { expect } from 'chai';
+
+describe('file-extension-utils', function() {
+
+  describe('getExtension()', function() {
+    it('return right extensions', function() {
+      expect(getExtension({ uri: 'file:///project/app.js' })).to.be.equal('.js');
+      expect(getExtension({ uri: 'file:///project/application.hbs' })).to.be.equal('.hbs');
+      expect(getExtension({ uri: 'file:///project/application.handlebars' })).to.be.equal('.hbs');
+      expect(getExtension({ uri: 'file:///project/application.css' })).to.be.equal('.css');
+    });
+  });
+
+  describe('hasExtension()', function() {
+    it('checks file has one of the provides extensions', function() {
+      expect(hasExtension({ uri: 'file:///project/app/app.js' }, '.js', '.hbs')).to.be.true;
+      expect(hasExtension({ uri: 'file:///project/app/application.hbs' }, '.js', '.hbs')).to.be.true;
+      expect(hasExtension({ uri: 'file:///project/app/application.handlebars' }, '.js', '.hbs')).to.be.true;
+      expect(hasExtension({ uri: 'file:///project/app/application.css' }, '.hbs')).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
The main difference is, that in `TemplateLinter` I use the file extension instead of the `languageId` to detect template files. In Atom the `Grammar::name` (lower case) [is used](https://github.com/atom/atom-languageclient/blob/0d61cfa859ce48c2657f4b917020959e4d68bf96/lib/adapters/document-sync-adapter.js#L84) to set the `languageId`. The Problem with that is, that in Atom the handlebars / htmltemplates do not have consistent grammar names ("HTML (Mustache)" or "Ember HTMLBars") because is depends on the extension you are using. But in no case it is "handlebars" like it seams to be in VSCode.

And this prevents template files to be linted.

I am not sure if this is actually should be fixed in atom/atom-languageclient or not. Unfortunately the Language Server Protocol [does not say much about the values of `languageId`](https://github.com/Microsoft/language-server-protocol/blob/e1ecd6a23a80735a1a7dc2abe3b684a7032e651e/protocol.md#textdocumentitem):

``` 
/**
 * The text document's language identifier.
 */
languageId: string;
```

So I figured using the file extension would be the safest way for now. (Also because in `DefinitionProvider` you are already using the file extension.)

And while I was on it create a util function `getExtension` mainly to accept both `.hbs` and `.handlebars` as template file extensions.

Let me know if that is suitable for you.