### PR TITLE
Better Diagnostic Messages

### DIFF
--- a/src/utils/diagnostic.ts
+++ b/src/utils/diagnostic.ts
@@ -1,0 +1,63 @@
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver';
+import { TemplateLinterError } from '../template-linter';
+
+const ParseErrorExp = /^Parse error on line (\d+)/;
+const OnLineErrorExp = / \(on line (\d+)\)\.$/;
+
+export function toDiagnostic(source: string, error: TemplateLinterError): Diagnostic {
+  return {
+    severity: DiagnosticSeverity.Error,
+    range: toRange(source, error),
+    message: toMessage(error),
+    source: error.rule ? 'ember-template-lint' : 'glimmer-engine'
+  };
+}
+
+function toLineRange(source: string, idx: number): [number, number] {
+  const line = (source.split('\n')[idx] || '').replace(/\s+$/, '');
+  const pre = line.match(/^(\s*)/);
+
+  const start = pre ? pre[1].length : 0;
+  const end = line.length || start + 1;
+
+  return [start, end];
+}
+
+function toMessage({ message }: TemplateLinterError): string {
+
+  if (ParseErrorExp.test(message)) {
+    return message.split('\n').pop() || '';
+  }
+
+  message = message.replace(OnLineErrorExp, '');
+
+  return message;
+}
+
+function toRange(source: string, error: TemplateLinterError): Range {
+
+  let line: number;
+  let column: number;
+
+  const match = error.message.match(ParseErrorExp) || error.message.match(OnLineErrorExp);
+  if (match) {
+    line = Number(match[1]) - 1;
+  } else if (error.line) {
+    line = error.line - 1;
+  } else {
+    line = 0;
+  }
+
+  const [start, end] = toLineRange(source, line);
+
+  if (typeof error.column === 'number') {
+    column = error.column;
+  } else {
+    column = start;
+  }
+
+  return {
+    start: { line, character: column },
+    end: { line, character: end }
+  };
+}

--- a/test/fixtures/dignostic/glimmer-compiler-error.json
+++ b/test/fixtures/dignostic/glimmer-compiler-error.json
@@ -1,0 +1,10 @@
+{
+  "source": "\n  <div></di  ",
+  "error":  {
+    "fatal": true,
+    "moduleId": "file:///path/to/project/template.hbs",
+    "message": "Unclosed element `div` (on line 2).",
+    "source": "Error: Unclosed element `div` (on line 2).\n    at Parser.Program (/path/to/project/node_modules/glimmer-engine/dist/node_modules/@glimmer/syntax/lib/parser/handlebars-node-visitors.js:20:19)\n    at Parser.acceptNode (/path/to/project/node_modules/glimmer-engine/dist/node_modules/@glimmer/syntax/lib/parser.js:44:31)\n    at Object.preprocess (/path/to/project/node_modules/glimmer-engine/dist/node_modules/@glimmer/syntax/lib/parser.js:19:46)\n    at precompile (/path/to/project/node_modules/glimmer-engine/dist/node_modules/@glimmer/compiler/lib/compiler.js:37:24)\n    at Linter.verify (/path/to/project/node_modules/ember-template-lint/lib/index.js:94:7)\n    at TemplateLinter.<anonymous> (/Users/josa/github/ember-language-server/lib/template-linter.js:34:35)\n    at Generator.next (<anonymous>)\n    at fulfilled (/Users/josa/github/ember-language-server/lib/template-linter.js:4:58)\n    at process._tickCallback (internal/process/next_tick.js:109:7)",
+    "severity": 2
+  }
+}

--- a/test/fixtures/dignostic/handlbars-parser-error.json
+++ b/test/fixtures/dignostic/handlbars-parser-error.json
@@ -1,0 +1,10 @@
+{
+  "source": "\n  {{}}  ",
+  "error": {
+    "fatal": true,
+    "moduleId": "file:///path/to/project/template.hbs",
+    "message": "Parse error on line 2:\n{{}}\n--^\nExpecting 'ID', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'CLOSE'",
+    "source": "Error: Parse error on line 2:\n{{}}\n--^\nExpecting 'ID', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'CLOSE'\n    at Parser.parseError (/path/to/project/node_modules/glimmer-engine/dist/node_modules/handlebars/compiler/parser.js:218:19)\n    at Parser.parse (/path/to/project/node_modules/glimmer-engine/dist/node_modules/handlebars/compiler/parser.js:287:30)\n    at HandlebarsEnvironment.parse (/path/to/project/node_modules/glimmer-engine/dist/node_modules/handlebars/compiler/base.js:45:43)\n    at Object.preprocess (/path/to/project/node_modules/glimmer-engine/dist/node_modules/@glimmer/syntax/lib/parser.js:18:64)\n    at precompile (/path/to/project/node_modules/glimmer-engine/dist/node_modules/@glimmer/compiler/lib/compiler.js:37:24)\n    at Linter.verify (/path/to/project/node_modules/ember-template-lint/lib/index.js:94:7)\n    at TemplateLinter.<anonymous> (/path/to/ember-language-server/lib/template-linter.js:33:35)\n    at Generator.next (<anonymous>)\n    at fulfilled (/path/to/ember-language-server/lib/template-linter.js:4:58)\n    at process._tickCallback (internal/process/next_tick.js:109:7)",
+    "severity": 2
+  }
+}

--- a/test/fixtures/dignostic/non-translated-error.json
+++ b/test/fixtures/dignostic/non-translated-error.json
@@ -1,0 +1,12 @@
+{
+  "source": "\n<span>Test</span>",
+  "error":  {
+    "moduleId": "file:///path/to/project/template.hbs",
+    "rule": "bare-strings",
+    "severity": 2,
+    "message": "Non-translated string used",
+    "line": 2,
+    "column": 6,
+    "source": "Test"
+  }
+}

--- a/test/utils/diagnostic-test.ts
+++ b/test/utils/diagnostic-test.ts
@@ -1,0 +1,50 @@
+const { expect } = require('chai');
+
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { toDiagnostic } from '../../src/utils/diagnostic';
+
+describe('diagnostic-utils', function() {
+  describe('toDiagnostic()', function() {
+    it('converts handlebars parser errors', function() {
+      const { source, error } = require('./fixtures/dignostic/handlbars-parser-error.json');
+
+      const diagnostic = toDiagnostic(source, error);
+
+      expect(diagnostic).to.have.deep.property('range.start.line', 1);
+      expect(diagnostic).to.have.deep.property('range.start.character', 2);
+      expect(diagnostic).to.have.deep.property('range.end.line', 1);
+      expect(diagnostic).to.have.deep.property('range.end.character', 6);
+      expect(diagnostic).to.have.property('severity', DiagnosticSeverity.Error);
+      expect(diagnostic).to.have.property('message', 'Expecting \'ID\', \'STRING\', \'NUMBER\', \'BOOLEAN\', \'UNDEFINED\', \'NULL\', \'DATA\', got \'CLOSE\'');
+      expect(diagnostic).to.have.property('source', 'glimmer-engine');
+    });
+
+    it('converts glimmer compiler errors', function() {
+      const { source, error } = require('./fixtures/dignostic/glimmer-compiler-error.json');
+
+      const diagnostic = toDiagnostic(source, error);
+
+      expect(diagnostic).to.have.deep.property('range.start.line', 1);
+      expect(diagnostic).to.have.deep.property('range.start.character', 2);
+      expect(diagnostic).to.have.deep.property('range.end.line', 1);
+      expect(diagnostic).to.have.deep.property('range.end.character', 11);
+      expect(diagnostic).to.have.property('severity', DiagnosticSeverity.Error);
+      expect(diagnostic).to.have.property('message', 'Unclosed element `div`');
+      expect(diagnostic).to.have.property('source', 'glimmer-engine');
+    });
+
+    it('converts unclosed element errors', function() {
+      const { source, error } = require('./fixtures/dignostic/non-translated-error.json');
+
+      const diagnostic = toDiagnostic(source, error);
+
+      expect(diagnostic).to.have.deep.property('range.start.line', 1);
+      expect(diagnostic).to.have.deep.property('range.start.character', 6);
+      expect(diagnostic).to.have.deep.property('range.end.line', 1);
+      expect(diagnostic).to.have.deep.property('range.end.character', 17);
+      expect(diagnostic).to.have.property('severity', DiagnosticSeverity.Error);
+      expect(diagnostic).to.have.property('message', 'Non-translated string used');
+      expect(diagnostic).to.have.property('source', 'ember-template-lint');
+    });
+  });
+});


### PR DESCRIPTION
I tries to improve the diagnostic messages by solving these problems:

- The end character is never provided
- Not all errors returned by `ember-template-lint` provide `line` and `column` informations.

I identified these error types:

## Errors caused by rules (`ember-template-lint`)

- `line`: Is provided
- `start.character`: Is provided (`column`)
- `end.character` End of line (without whitespace)

```
{
  "message": "Non-translated string used",
  "line": 2,
  "column": 6
}
```
<img width="1000" alt="screen shot 2017-05-30 at 16 37 19" src="https://cloud.githubusercontent.com/assets/423234/26588778/8e9a5f0c-4556-11e7-8edd-5bbac1d8bbe5.png">

## Errors caused by syntax errors (`handlebars`)

- `line`: Is provided in the message and extracted by a RegExp
- `start.character`: Start of line (without whitespace)
- `end.character` End of line (without whitespace)

```
{
"message": "Parse error on line 2:\n{{}}\n--^\nExpecting 'ID', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'CLOSE'"
}
```

<img width="1000" alt="screen shot 2017-05-30 at 16 37 01" src="https://cloud.githubusercontent.com/assets/423234/26588894/dfac691c-4556-11e7-8627-48a2abd342cd.png">


## Errors caused syntax errors (`glimmer-engine`)

- `line`: Is provided in the message and extracted by a RegExp
- `start.character`: Start of line (without whitespace)
- `end.character` End of line (without whitespace)

```
{
  "message": "Unclosed element `div` (on line 2)."
}
```

<img width="1000" alt="screen shot 2017-05-30 at 16 38 20" src="https://cloud.githubusercontent.com/assets/423234/26588934/fa6110d2-4556-11e7-894d-a9283c311737.png">
