### PR TITLE
Run tests on Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: node_js
 
 node_js:
   - '6'
+  - '7'
 
 script:
   - npm run compile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "6"
+  matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "7"
 
 # Make bors happy
 branches:


### PR DESCRIPTION
VSCode runs the language server with the same Node version that is included with Electron (which is 7.4.0), so I think we should definitely test it on Node 7.

AFAIK the Atom client runs it with whatever version the user has installed, so we should probably leave Node 6 in there and maybe add 8 going forward (but maybe @josa42 can correct me if I am wrong).