### PR TITLE
Fix error in textDocument/completion

### DIFF
--- a/src/completion-provider/template-completion-provider.ts
+++ b/src/completion-provider/template-completion-provider.ts
@@ -175,6 +175,6 @@ function toCompletionItemKind(type: string): CompletionItemKind {
   }
 }
 
-function getTextPrefix({ node }: ASTPath): string {
-  return node && node.original.replace('ELSCompletionDummy', '');
+function getTextPrefix({ node: { original = '' } }: ASTPath): string {
+  return original.replace('ELSCompletionDummy', '');
 }


### PR DESCRIPTION
In some cases `node.original` seams to be undefined witch causes this error:

> Request textDocument/completion failed with message: Cannot read property 'replace' of undefined