### PR TITLE
Run tests on Node 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
-branches:
-  except:
-    - staging.tmp
-
 language: node_js
 
 node_js:
-  - '6'
   - '7'
+  - '8'
 
 script:
   - yarn compile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    - nodejs_version: "6"
     - nodejs_version: "7"
-
-# Make bors happy
-branches:
-  except:
-    - staging.tmp
+    - nodejs_version: "8"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
Our main targets (VSCode and Atom) currently come with either Node 7 or 8, so we should test with these versions.