### PR TITLE
Replace esprima with Babylon

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@glimmer/syntax": "^0.33.4",
     "ast-types": "^0.11.3",
-    "esprima": "^4.0.0",
+    "babylon": "^6.18.0",
     "fs-extra": "^5.0.0",
     "fuzzaldrin": "^2.1.0",
     "i": "^0.3.5",
@@ -23,7 +23,7 @@
     "walk-sync": "^0.3.2"
   },
   "devDependencies": {
-    "@types/esprima": "^4.0.1",
+    "@types/babylon": "^6.16.2",
     "@types/estree": "*",
     "@types/fuzzaldrin": "^2.1.1",
     "@types/jest": "^22.2.3",

--- a/src/symbols/js-document-symbol-provider.ts
+++ b/src/symbols/js-document-symbol-provider.ts
@@ -1,5 +1,5 @@
 import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
-import { parseModule } from 'esprima';
+import { parse } from 'babylon';
 import DocumentSymbolProvider from './document-symbol-provider';
 import { toLSRange } from '../estree-utils';
 
@@ -9,8 +9,8 @@ export default class JSDocumentSymbolProvider implements DocumentSymbolProvider 
   extensions: string[] = ['.js'];
 
   process(content: string): SymbolInformation[] {
-    let ast = parseModule(content, {
-      loc: true
+    const ast = parse(content, {
+      sourceType: 'module'
     });
 
     let symbols: SymbolInformation[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,11 +41,15 @@
   dependencies:
     "@glimmer/util" "^0.33.4"
 
-"@types/esprima@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/esprima/-/esprima-4.0.1.tgz#40f6fb3a3a50ebcaa4dfca17f41e7f10e687df03"
+"@types/babel-types@*":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-7.0.1.tgz#1405e5396968c4302994b0161ce405b72b874257"
+
+"@types/babylon@^6.16.2":
+  version "6.16.2"
+  resolved "https://registry.yarnpkg.com/@types/babylon/-/babylon-6.16.2.tgz#062ce63b693d9af1c246f5aedf928bc9c30589c8"
   dependencies:
-    "@types/estree" "*"
+    "@types/babel-types" "*"
 
 "@types/estree@*":
   version "0.0.38"


### PR DESCRIPTION
Babylon recently added the ability to parse TypeScript files. So changing to Babylon enables us to parse TS and JS files with the same logic which should make it easier in the future to add the features of the language server for TypeScript projects.