### PR TITLE
Fix "Go to Definition" for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "fuzzaldrin": "^2.1.0",
     "i": "^0.3.5",
     "vscode-languageserver": "^4.1.2",
+    "vscode-uri": "^1.0.6",
     "walk-sync": "^0.3.2"
   },
   "devDependencies": {

--- a/src/completion-provider/template-completion-provider.ts
+++ b/src/completion-provider/template-completion-provider.ts
@@ -6,8 +6,6 @@ import {
   TextDocumentPositionParams
 } from 'vscode-languageserver';
 
-import { uriToFilePath } from 'vscode-languageserver/lib/files';
-
 import Server from '../server';
 import ASTPath from '../glimmer-utils';
 import { toPosition } from '../estree-utils';
@@ -21,6 +19,7 @@ import {
   emberSubExpressionItems
 } from './ember-helpers';
 import uniqueBy from '../utils/unique-by';
+import { getExtension } from '../utils/file-extension';
 
 const walkSync = require('walk-sync');
 
@@ -29,13 +28,12 @@ export default class TemplateCompletionProvider {
 
   provideCompletions(params: TextDocumentPositionParams): CompletionItem[] {
     const uri = params.textDocument.uri;
-    const filePath = uriToFilePath(uri);
 
-    if (!filePath || extname(filePath) !== '.hbs') {
+    if (getExtension(params.textDocument) !== '.hbs') {
       return [];
     }
 
-    const project = this.server.projectRoots.projectForPath(filePath);
+    const project = this.server.projectRoots.projectForUri(uri);
     if (!project) {
       return [];
     }

--- a/src/definition-provider.ts
+++ b/src/definition-provider.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 import { RequestHandler, TextDocumentPositionParams, Definition, Location, Range } from 'vscode-languageserver';
-import { uriToFilePath } from 'vscode-languageserver/lib/files';
 
 import { parse } from 'babylon';
 
@@ -18,12 +17,8 @@ export default class DefinitionProvider {
 
   handle(params: TextDocumentPositionParams): Definition | null {
     let uri = params.textDocument.uri;
-    let filePath = uriToFilePath(uri);
-    if (!filePath) {
-      return null;
-    }
 
-    const project = this.server.projectRoots.projectForPath(filePath);
+    const project = this.server.projectRoots.projectForUri(uri);
     if (!project) {
       return null;
     }

--- a/src/definition-provider.ts
+++ b/src/definition-provider.ts
@@ -9,6 +9,7 @@ import { toPosition } from './estree-utils';
 import Server from './server';
 import ASTPath from './glimmer-utils';
 import { getExtension } from './utils/file-extension';
+import URI from 'vscode-uri';
 
 const { preprocess } = require('@glimmer/syntax');
 
@@ -111,6 +112,6 @@ function pathsToLocations(...paths: string[]): Location[] {
   return paths
     .filter(fs.existsSync)
     .map(modulePath => {
-      return Location.create(`file://${modulePath}`, Range.create(0, 0, 0, 0));
+      return Location.create(URI.file(modulePath).toString(), Range.create(0, 0, 0, 0));
     });
 }

--- a/src/project-roots.ts
+++ b/src/project-roots.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { dirname, join } from 'path';
+import { uriToFilePath } from 'vscode-languageserver/lib/files';
 
 const walkSync = require('walk-sync');
 
@@ -41,9 +42,14 @@ export default class ProjectRoots {
     this.projects.set(path, new Project(path));
   }
 
-  projectForPath(path: string): Project | undefined {
+  projectForUri(uri: string): Project | undefined {
+    let path = uriToFilePath(uri);
+
+    if (!path)
+      return;
+
     let root = (Array.from(this.projects.keys()) || [])
-      .filter(root => path.indexOf(root) === 0)
+      .filter(root => path!.indexOf(root) === 0)
       .reduce((a, b) => a.length > b.length ? a : b, '');
 
     return this.projects.get(root);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import {
   IPCMessageReader, IPCMessageWriter,
   createConnection, IConnection,
   TextDocuments, InitializeResult, InitializeParams, DocumentSymbolParams,
-  SymbolInformation, Files, TextDocumentPositionParams, CompletionItem
+  SymbolInformation, TextDocumentPositionParams, CompletionItem
 } from 'vscode-languageserver';
 
 import ProjectRoots from './project-roots';
@@ -22,6 +22,7 @@ import JSDocumentSymbolProvider from './symbols/js-document-symbol-provider';
 import HBSDocumentSymbolProvider from './symbols/hbs-document-symbol-provider';
 
 import TemplateCompletionProvider from './completion-provider/template-completion-provider';
+import { uriToFilePath } from 'vscode-languageserver/lib/files';
 
 export default class Server {
 
@@ -67,7 +68,7 @@ export default class Server {
   // in the passed params the rootPath of the workspace plus the client capabilites.
   private onInitialize({ rootUri, rootPath }: InitializeParams): InitializeResult {
 
-    rootPath = rootUri ? Files.uriToFilePath(rootUri) : rootPath;
+    rootPath = rootUri ? uriToFilePath(rootUri) : rootPath;
     if (!rootPath) {
       return { capabilities: {} };
     }
@@ -109,7 +110,7 @@ export default class Server {
 
   private onDocumentSymbol(params: DocumentSymbolParams): SymbolInformation[] {
     let uri = params.textDocument.uri;
-    let filePath = Files.uriToFilePath(uri);
+    let filePath = uriToFilePath(uri);
     if (!filePath) {
       return [];
     }

--- a/src/template-linter.ts
+++ b/src/template-linter.ts
@@ -1,5 +1,4 @@
 import { Diagnostic, Files, TextDocument } from 'vscode-languageserver';
-import { uriToFilePath } from 'vscode-languageserver/lib/files';
 import { hasExtension } from './utils/file-extension';
 import { toDiagnostic } from './utils/diagnostic';
 
@@ -55,12 +54,7 @@ export default class TemplateLinter {
   }
 
   private getLinterConfig(uri: string): { configPath: string } | undefined {
-    const filePath = uriToFilePath(uri);
-    if (!filePath) {
-      return;
-    }
-
-    const project = this.server.projectRoots.projectForPath(filePath);
+    const project = this.server.projectRoots.projectForUri(uri);
     if (!project) {
       return;
     }
@@ -74,12 +68,7 @@ export default class TemplateLinter {
   }
 
   private async getLinter(uri: string) {
-    const filePath = uriToFilePath(uri);
-    if (!filePath) {
-      return;
-    }
-
-    const project = this.server.projectRoots.projectForPath(filePath);
+    const project = this.server.projectRoots.projectForUri(uri);
     if (!project) {
       return;
     }

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -35,6 +35,7 @@ function replaceDynamicUriPart(uri: string) {
   }
 
   return uri
+    .replace(dirname.replace(/\\/g, '/'), '/path-to-tests')
     .replace(dirname, '/path-to-tests')
     .replace(/\\/g, '/');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,6 +3921,11 @@ vscode-uri@^1.0.1:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.1.tgz#11a86befeac3c4aa3ec08623651a3c81a6d0bbc8"
   integrity sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=
 
+vscode-uri@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.6.tgz#6b8f141b0bbc44ad7b07e94f82f168ac7608ad4d"
+  integrity sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"


### PR DESCRIPTION
This fixes issues with using "Go to Definition" and "Peek Definition" in VS Code on Windows. 

Previously, attempting to use Go to Definition would result in an error, `Unable to open 'c:\Users\<user>\EmberApp\app\helpers\helper-file.js': File is a directory.` 

This is because it was returning a filepath that looked like
 `file://c:\Users\<user>\Repository\EmberApp\app\helpers\helper-file.js`. 
VS Code expected a value like 
`file:///c%3A/Users/<user>/EmberApp/app/helpers/helper-file.js` 

In order to get reliable values, I added the `vscode-uri` dependency, and used `URI.file(modulePath).toString();` which seems fairly standard based on my examination of similar repos here on GitHub. I also had to tweak some utility code in the tests that normalizes return paths to account for the difference between forward and backward slashes.

Additionally, I deduplicated some code for converting uri's to filepaths and using those filepaths to determine the project root. I think in the future we may want to go further in using the official `URI` library for handling uri, and centralizing the code will help with that.

It's probably a good idea to add tests that will ensure that this continues to work on all OS's, but I'm not sure how to go about that, or if it's needed. 
