### PR TITLE
:tv: fix windows build support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^12.7.8",
     "jest": "^23.6.0",
     "lerna-changelog": "^0.8.2",
+    "rimraf": "^3.0.0",
     "ts-jest": "^22.4.3",
     "tslint": "^5.20.0",
     "typescript": "^2.8.1",
@@ -43,7 +44,7 @@
   },
   "scripts": {
     "changelog": "lerna-changelog",
-    "clean": "rm -rf lib/",
+    "clean": "rimraf lib/",
     "compile": "tsc -p .",
     "lint": "tslint --project ./tsconfig.json",
     "prepublish": "yarn clean && yarn compile",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,6 +1580,18 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -3832,6 +3844,13 @@ rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
+
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
replace `rm -rf` in package.json with `rimraf`

right now `yarn install` fails on windows

this is related to changes here: https://github.com/NullVoxPopuli/coc-ember/pull/3